### PR TITLE
feat: Add styling to both buttons

### DIFF
--- a/foundations/03-grouping-selectors/index.html
+++ b/foundations/03-grouping-selectors/index.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="style.css">
   </head>
   <body>
-    <button>Click Me!</button>
-    <button>No, Click Me!</button>
+    <button class="button1">Click Me!</button>
+    <button class="button2">No, Click Me!</button>
   </body>
 </html>

--- a/foundations/03-grouping-selectors/style.css
+++ b/foundations/03-grouping-selectors/style.css
@@ -1,0 +1,15 @@
+.button1 {
+    background-color: black;
+    color: white;
+    font-weight: bold;
+}
+
+.button2 {
+    background-color: yellow;
+}
+
+.button1,
+.button2 {
+    font-size: 28px;
+    font-family: Helvetica, 'Times New Roman', sans-serif;
+}


### PR DESCRIPTION
## Info
This PR adds the necessary styling which matches the desired outcome image for the exercise 03-grouping-selectors activity in the foundations folder.

What has been added is:
- Classes for both buttons to be individually styled.
- CSS declarations that both individual select these classes but also group select both classes to apply these styling:
   - `button1`: Black background, White text, Bold font-weight.
   - `button2`: Yellow Background
   - Both `button1` and `button2`: 28px font size, fonts listing of: Helvetica, Times New Roman, and sans-serif as a fallback.

**Outcome:**

![image](https://github.com/danielelli/css-exercises/assets/90986300/e5a80ce6-0d81-4298-9cef-4b60a78815ef)
