### PR TITLE
feat: Add styling to top avatar images

### DIFF
--- a/foundations/04-chaining-selectors/style.css
+++ b/foundations/04-chaining-selectors/style.css
@@ -1,1 +1,10 @@
 /* Add CSS Styling */
+.avatar.proportioned {
+    width: 300px;
+    height: 100%;
+}
+
+.avatar.distorted {
+    width: 200px;
+    height: 400px;
+}


### PR DESCRIPTION
## Info

This PR adds styles to the top left and right avatar images which match the specifications provided in exercise `04-Chaining-Selectors` README file and accurately represents it's respective desired outcome image.

What has been added is:
- A chained class-selector for both the `avatar` class and `proportioned` class making any element with both of these classes 300px wide but also retaining original height.
- A chained class-selector for both the `avatar` class and `distorted` class making any element with both of these classes 200px wide and a height of 400px.

Outcome:

![image](https://github.com/danielelli/css-exercises/assets/90986300/3921390b-711b-425c-a6b9-99323965be6a)
