### PR TITLE
feat: Add styling to descendants of both div containers

### DIFF
--- a/foundations/05-descendant-combinator/style.css
+++ b/foundations/05-descendant-combinator/style.css
@@ -1,0 +1,6 @@
+.container .text {
+    background-color: yellow;
+    color: red;
+    font-size: 20px;
+    text-align: center;
+}


### PR DESCRIPTION
## Info

This PR adds styling to all elements with the class `text` that are descendants of any `div` element with the class `container` matching the specifications of the exercise `05-descendant-combinator` and it's respective desired outcome image.

What has been added is:
- A descendant combinator selector for all `text` classes in the ancestor class of `container`.
- Gives the descendants these stylings:
  - Yellow background
  - Red text
  - Font-size of 20px
  - Aligning text in the center

Outcome:
![Screenshot 2024-04-10 010312](https://github.com/danielelli/css-exercises/assets/90986300/0e295836-2597-4f73-88ef-d9b6b993835f)
