### PR TITLE
fix: Edit style.css to fix declarations to properly cascade

### DIFF
--- a/foundations/06-cascade-fix/style.css
+++ b/foundations/06-cascade-fix/style.css
@@ -8,16 +8,16 @@ body {
   font-weight: 800;
 }
 
+.para {
+  font-size: 22px;
+}
+
 .small-para {
   font-size: 14px;
   font-weight: 800;
 }
 
-.para {
-  font-size: 22px;
-}
-
-.confirm {
+#confirm-button {
   background: green;
   color: white;
   font-weight: bold;
@@ -29,7 +29,7 @@ body {
   font-size: 20px;
 }
 
-.child {
+.text .child {
   color: rgb(0, 0, 0);
   font-weight: 800;
   font-size: 14px;


### PR DESCRIPTION
## Info

This PR fixes the positioning and selector choice in `style.css` to allow proper cascading to the styling of the webpage elements matching the desired outcome specified in the instructions for `06-cascade-fix` exercise. 

What has been added is:
- edits to the `.para` class position in the cascade.
- edits to several selector declarations to include additional classes to maintain deliberate specificity.

Outcome:

![image](https://github.com/danielelli/css-exercises/assets/90986300/659698c0-03ad-4f46-8798-1ad121d4408e)