### PR TITLE
Solution for 05-flex-modal exercise

### DIFF
--- a/flex/04-flex-information/index.html
+++ b/flex/04-flex-information/index.html
@@ -10,18 +10,24 @@
   <body>
     <div class="title">Information!</div>
 
-    <img src="./images/barberry.png" alt="barberry">
-    <div class="text">This is a type of plant. We love this one.</div>
-
-    <img src="./images/chilli.png" alt="chili">
-    <div class="text">This is another type of plant. Isn't it nice?</div>
-
-    <img src="./images/pepper.png" alt="pepper">
-    <div class="text">We have so many plants. Yay plants.</div>
-
-    <img src="./images/saffron.png" alt="saffron">
-    <div class="text">I'm running out of things to say about plants.</div>
-
+    <div class="container">
+      <div class="plant-container">
+        <img src="./images/barberry.png" alt="barberry">
+        <div class="text">This is a type of plant. We love this one.</div>
+      </div>
+      <div class="plant-container">
+        <img src="./images/chilli.png" alt="chili">
+        <div class="text">This is another type of plant. Isn't it nice?</div>
+      </div>
+      <div class="plant-container">
+        <img src="./images/pepper.png" alt="pepper">
+        <div class="text">We have so many plants. Yay plants.</div>
+      </div>
+      <div class="plant-container">
+        <img src="./images/saffron.png" alt="saffron">
+        <div class="text">I'm running out of things to say about plants.</div>
+      </div>
+    </div>
     <!-- disregard this section, it's here to give attribution to the creator of these icons -->
     <div class="footer">
       <div>Icons made by <a href="https://www.flaticon.com/authors/icongeek26" title="Icongeek26">Icongeek26</a> from <a href="https://www.flaticon.com/" title="Flaticon">www.flaticon.com</a></div>

--- a/flex/04-flex-information/style.css
+++ b/flex/04-flex-information/style.css
@@ -1,5 +1,6 @@
 body {
   font-family: 'Courier New', Courier, monospace;
+  text-align: center;
 }
 
 img {
@@ -10,6 +11,17 @@ img {
 .title {
   font-size: 36px;
   font-weight: 900;
+  margin-bottom: 32px;
+}
+
+.container {
+  display: flex;
+  justify-content: center;
+  gap: 52px;
+}
+
+.plant-container {
+  max-width: 200px;
 }
 
 /* do not edit this footer */

--- a/flex/05-flex-modal/index.html
+++ b/flex/05-flex-modal/index.html
@@ -9,12 +9,19 @@
   </head>
   <body>
     <div class="modal">
-      <div class="icon">!</div>
-      <div class="header">Are you sure you want to do that?</div>
-      <button class="close-button">✖</button>
-      <div class="text">Lorem ipsum dolor sit amet consectetur adipisicing elit. Pariatur excepturi id soluta, numquam minima rerum doloremque eveniet aspernatur beatae commodi. Cupiditate recusandae ad repellendus quidem consectetur sequi amet aspernatur cumque!</div>
-      <button class="continue">Continue</button>
-      <button class="cancel">Cancel</button>
+      <div class="left">
+        <div class="icon">!</div>
+      </div>
+      <div class="right">
+        <div class="header">Are you sure you want to do that?
+          <button class="close-button">✖</button>
+        </div>
+        <div class="text">Lorem ipsum dolor sit amet consectetur adipisicing elit. Pariatur excepturi id soluta, numquam minima rerum doloremque eveniet aspernatur beatae commodi. Cupiditate recusandae ad repellendus quidem consectetur sequi amet aspernatur cumque!</div>
+        <div class="buttons">
+          <button class="continue">Continue</button>
+          <button class="cancel">Cancel</button>
+        </div>
+      </div>
     </div>
   </body>
 </html>

--- a/flex/05-flex-modal/style.css
+++ b/flex/05-flex-modal/style.css
@@ -20,6 +20,9 @@ body {
   width: 480px;
   border-radius: 10px;
   box-shadow: 2px 4px 16px rgba(0,0,0,.2);
+  padding: 16px;
+  gap: 16px;
+  display: flex;
 }
 
 .icon {
@@ -48,6 +51,23 @@ body {
   justify-content: center;
   border: 1px solid #eee;
   padding: 0;
+}
+
+.left {
+  display: flex;
+}
+
+.right {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.header {
+  font-weight: bold;
+  font-size: 18px;
+  display: flex;
+  justify-content: space-between;
 }
 
 button {


### PR DESCRIPTION
## Info

This PR adds a solution for the `05-flex-modal` exercise. Created new div containers to redesign the modal layout to fit the desired outcome instructions, a trick I used to get to this point was to use different `background-color` on flex items to see where I wanted the specific containers to go.

Outcome:
![image](https://github.com/danielelli/css-exercises/assets/90986300/951dd537-16ef-4d03-8a73-0e97c528e557)
